### PR TITLE
 Fix css when displaying groups

### DIFF
--- a/Template/board/group.php
+++ b/Template/board/group.php
@@ -1,7 +1,7 @@
 <span>
 <?php if ($task['assigned_groupname']): ?>
      <strong><?= t('Assigned Group:') ?></strong>
-     <span class="assigned-group" style="background-color: #<?= $this->task->groupColorExtension->getGroupColor($task['assigned_groupname']) ?>" color:"<?= $this->task->groupColorExtension->getFontColor($this->task->groupColorExtension->getGroupColor($task['assigned_groupname'])) ?>"><?= $this->text->e($task['assigned_groupname'] ?: $task['owner_gp']) ?></span>
+     <span class="assigned-group" style="background-color: #<?= $this->task->groupColorExtension->getGroupColor($task['assigned_groupname']) ?>; color:"<?= $this->task->groupColorExtension->getFontColor($this->task->groupColorExtension->getGroupColor($task['assigned_groupname'])) ?>;"><?= $this->text->e($task['assigned_groupname'] ?: $task['owner_gp']) ?></span>
      <br>
 <?php endif ?>
 </span>

--- a/Template/board/group.php
+++ b/Template/board/group.php
@@ -1,7 +1,7 @@
 <span>
 <?php if ($task['assigned_groupname']): ?>
      <strong><?= t('Assigned Group:') ?></strong>
-     <span class="assigned-group" style="background-color: #<?= $this->task->groupColorExtension->getGroupColor($task['assigned_groupname']) ?>; color:"<?= $this->task->groupColorExtension->getFontColor($this->task->groupColorExtension->getGroupColor($task['assigned_groupname'])) ?>;"><?= $this->text->e($task['assigned_groupname'] ?: $task['owner_gp']) ?></span>
+     <span class="assigned-group" style="background-color: #<?= $this->task->groupColorExtension->getGroupColor($task['assigned_groupname']) ?>; color:<?= $this->task->groupColorExtension->getFontColor($this->task->groupColorExtension->getGroupColor($task['assigned_groupname'])) ?>;"><?= $this->text->e($task['assigned_groupname'] ?: $task['owner_gp']) ?></span>
      <br>
 <?php endif ?>
 </span>

--- a/Template/task/details.php
+++ b/Template/task/details.php
@@ -2,7 +2,7 @@
                         <strong><?= t('Assigned Group:') ?></strong>
                         <span>
                         <?php if ($task['assigned_groupname']): ?>
-                            <span class="assigned-group" style="background-color: #<?= $this->task->groupColorExtension->getGroupColor($task['assigned_groupname']) ?>; color:"<?= $this->task->groupColorExtension->getFontColor($this->task->groupColorExtension->getGroupColor($task['assigned_groupname'])) ?>;"><?= $this->text->e($task['assigned_groupname'] ?: $task['owner_gp']) ?></span>
+                            <span class="assigned-group" style="background-color: #<?= $this->task->groupColorExtension->getGroupColor($task['assigned_groupname']) ?>; color:<?= $this->task->groupColorExtension->getFontColor($this->task->groupColorExtension->getGroupColor($task['assigned_groupname'])) ?>;"><?= $this->text->e($task['assigned_groupname'] ?: $task['owner_gp']) ?></span>
                         <?php else: ?>
                             <?= t('not assigned') ?>
                         <?php endif ?>


### PR DESCRIPTION
Typo issue, the style tag was closed before color.

**Before fix:**
```html
<span class="assigned-group" style="background-color: #000000" color:"#ff3fe4">MyGroup</span>
```
**With fix:**
```html
<span class="assigned-group" style="background-color: #000000; color:#ff3fe4;">MyGroup</span>
```