### PR TITLE
Added Translation "Deutsch (du)"

### DIFF
--- a/Locale/de_DE_du/translations.php
+++ b/Locale/de_DE_du/translations.php
@@ -1,0 +1,13 @@
+<?php
+
+return array(
+		'Assigned Group' => 'Zugeordnete Gruppe',
+    'Assigned Group:' => 'Zugeordnete Gruppe:',
+    'Other Assignees' => 'Weitere Zuordnungen',
+    'Other Assignees:' => 'Weitere Zuordnungen:',
+    'Send a task by email to assigned group members' => 'Senden einer Aufgabe per E-Mail an zugewiesene Gruppenmitglieder',
+		'Send a task by email to the other assignees for a task.' => 'Aufgabe per E-Mail an die weiteren zugeordneten der Aufgabe senden',
+		'Send email notification of impending due date to Group Members Assigned' => 'E-Mail-Benachrichtigung über bevorstehendes Fälligkeitsdatum an die zugewiesenen Gruppenmitglieder senden',
+		'Send email notification of impending due date to the other assignees of a task' => 'E-Mail-Benachrichtigung über das bevorstehende Fälligkeitsdatum an die anderen Empfänger einer Aufgabe senden',
+    'Assign the task to a specific group' => 'Aufgabe einer bestimmten Gruppe zuordnen'
+);


### PR DESCRIPTION
With [this approved pull-request](https://github.com/kanboard/kanboard/pull/4767) the German translation will now come in 2 flavours.
This PR adds the new German flavour "Deutsch (du)" to the GroupAssign-plugin