### PR TITLE
name parameter according to input

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -111,9 +111,9 @@ class Plugin extends Base
         $this->template->hook->attach('template:board:private:task:before-title', 'group_assign:board/group');
         $this->template->hook->attach('template:board:private:task:before-title', 'group_assign:board/multi');
         $groupmodel = $this->projectGroupRoleModel;
-        $this->template->hook->attachCallable('template:app:filters-helper:after', 'group_assign:board/filter', function($array = array()) use ($groupmodel) {
-            if(!empty($array) && $array['id'] >= 1){
-                return ['grouplist' => array_column($groupmodel->getGroups($array['id']), 'name')];
+        $this->template->hook->attachCallable('template:app:filters-helper:after', 'group_assign:board/filter', function($project = array()) use ($groupmodel) {
+            if(!empty($project) && $project['id'] >= 1){
+                return ['grouplist' => array_column($groupmodel->getGroups($project['id']), 'name')];
             } else {
                 return ['grouplist' => array()];
             }


### PR DESCRIPTION
[php 8 supports named parameters](https://php.watch/versions/8.0/named-parameters) 

the very last part is about backwards-compatibility with `call_user_func_array`, so it might be necessary to change it kanboard base accordingly.

![image](https://user-images.githubusercontent.com/13346344/135864071-982869d1-afa2-4b48-8975-6e1998e24f36.png)

This change also fixes the error as the name now equals the name from out of the array.
