### PR TITLE
fix: Kanboard version detection fails after branch rename

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -48,7 +48,9 @@ class Plugin extends Base
 
         //Models and backward compatibility
         $applications_version = str_replace('v', '', APP_VERSION);
-        if (strpos(APP_VERSION, 'master') !== false && file_exists('ChangeLog')) { $applications_version = trim(file_get_contents('ChangeLog', false, null, 8, 6), ' '); }
+        if ((strpos(APP_VERSION, 'master') !== false || strpos(APP_VERSION, 'main') !== false) && file_exists('ChangeLog')) {
+            $applications_version = trim(file_get_contents('ChangeLog', false, null, 8, 6), ' ');
+        }
         $clean_appversion = preg_replace('/\s+/', '', $applications_version);
 
         if (version_compare($clean_appversion, '1.2.5', '>')) {


### PR DESCRIPTION
Hi,

This PR seeks to fix a bug where the currently running Kanboard development version isn't properly detected, leading to the wrong compatibility classes being loaded, resulting in bugs such as a missing task category color.

A while back the Kanboard project switched its default branch name from `master` to `main` ([7d0647](https://github.com/kanboard/kanboard/commit/7d0647cbed297d81e47910ba92357822acceed7c)). The compatibility check of this plugin used to [detect a development version](https://github.com/creecros/Group_assign/blob/c5c24fa8c6ef7c9bc0343e131f7d1c4ea8f9937c/Plugin.php#L51) of Kanboard by a leading `master` string. This PR expands this check to also check for `main`, if `master` isn't found, to ensure the right compatibility classes are loaded.
