### PR TITLE
refactor: extend TaskProjectDuplicationModel through inheritance

### DIFF
--- a/Model/TaskProjectDuplicationModel.php
+++ b/Model/TaskProjectDuplicationModel.php
@@ -2,13 +2,9 @@
 
 namespace Kanboard\Plugin\Group_assign\Model;
 
-use Kanboard\Model\TaskDuplicationModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\ProjectGroupRoleModel;
-use Kanboard\Plugin\Group_assign\Model\MultiselectMemberModel;
-use Kanboard\Plugin\Group_assign\Model\MultiselectModel;
-use Kanboard\Model\ProjectPermissionModel;
-use Kanboard\Model\TaskLinkModel;
+use Kanboard\Model\TaskProjectDuplicationModel as KanboardTaskProjectDuplicationModel;
 
 /**
  * Task Project Duplication
@@ -16,7 +12,7 @@ use Kanboard\Model\TaskLinkModel;
  * @package  Kanboard\Plugins\Group_assign
  * @author   Craig Crosby
  */
-class TaskProjectDuplicationModel extends TaskDuplicationModel
+class TaskProjectDuplicationModel extends KanboardTaskProjectDuplicationModel
 {
     /**
      * Duplicate a task to another project
@@ -33,9 +29,8 @@ class TaskProjectDuplicationModel extends TaskDuplicationModel
     public function duplicateToProject($task_id, $project_id, $swimlane_id = null, $column_id = null, $category_id = null, $owner_id = null, $owner_gp = 0, $owner_ms = 0)
     {
         $values = $this->prepare($task_id, $project_id, $swimlane_id, $column_id, $category_id, $owner_id);
+        $new_task_id = parent::duplicateToProject($task_id, $project_id, $swimlane_id, $column_id, $category_id, $owner_id);
 
-        $this->checkDestinationProjectValues($values);
-        $new_task_id = $this->save($task_id, $values);
         if ($new_task_id !== false) {
             // Check if the group is allowed for the destination project
             $group_id = $this->db->table(TaskModel::TABLE)->eq('id', $task_id)->findOneColumn('owner_gp');
@@ -62,35 +57,8 @@ class TaskProjectDuplicationModel extends TaskDuplicationModel
                     }
                 }
             }
-
-            $this->tagDuplicationModel->duplicateTaskTagsToAnotherProject($task_id, $new_task_id, $project_id);
-            $this->taskLinkModel->create($new_task_id, $task_id, 4);
         }
 
         return $new_task_id;
-    }
-
-    /**
-     * Prepare values before duplication
-     *
-     * @access protected
-     * @param  integer $task_id
-     * @param  integer $project_id
-     * @param  integer $swimlane_id
-     * @param  integer $column_id
-     * @param  integer $category_id
-     * @param  integer $owner_id
-     * @return array
-     */
-    protected function prepare($task_id, $project_id, $swimlane_id, $column_id, $category_id, $owner_id)
-    {
-        $values = $this->copyFields($task_id);
-        $values['project_id'] = $project_id;
-        $values['column_id'] = $column_id !== null ? $column_id : $values['column_id'];
-        $values['swimlane_id'] = $swimlane_id !== null ? $swimlane_id : $values['swimlane_id'];
-        $values['category_id'] = $category_id !== null ? $category_id : $values['category_id'];
-        $values['owner_id'] = $owner_id !== null ? $owner_id : $values['owner_id'];
-
-        return $values;
     }
 }


### PR DESCRIPTION
Hi,

this PR refactors the TaskProjectDuplicationModel to inherit the base functionality from Kanboard's version of the same class and adds the plugin-specific logic by overriding the `duplicateToProject` method.

This way code duplication is avoided and the plugin benefits from Kanboard's updates to that class. 

Let me know any feedback you might have.