### PR TITLE
Update EmailGroup.php

### DIFF
--- a/Action/EmailGroup.php
+++ b/Action/EmailGroup.php
@@ -19,6 +19,7 @@ class EmailGroup extends Base
             TaskModel::EVENT_MOVE_COLUMN,
             TaskModel::EVENT_CLOSE,
             TaskModel::EVENT_CREATE,
+            TaskModel::EVENT_UPDATE
         );
     }
 


### PR DESCRIPTION
add compatible event for update

For older automatic actions, the "Update" option was available and displayed. When creating new actions, this option was no longer available.

